### PR TITLE
ARC-180: Keep search groups applied when changing pages

### DIFF
--- a/src/api/item-api.js
+++ b/src/api/item-api.js
@@ -3,9 +3,18 @@ import config from '~/config';
 import $ from 'jquery';
 import { CONTENT_TYPES } from '~/src/state/viewer/viewer-constants';
 import { APP_CONSTANTS } from '~/src/utils/app-constants';
+import { buildSearchPayload } from '~/src/api/search-api';
 
 export function fetchItems(pageNumber) {
-    return ajax('GET', `documents?page=${pageNumber}`);
+    const searchGroups = store.getState().search.searchGroups;
+    if (searchGroups.length == 0) {
+        return ajax('GET', `documents?page=${pageNumber}`);
+    } else {
+        const payload = {
+            search: buildSearchPayload(searchGroups),
+        }
+        return ajax('POST', `documents/search?page=${pageNumber}`, payload);
+    }
 }
 
 export function fetchItem(itemId) {

--- a/src/api/item-api.js
+++ b/src/api/item-api.js
@@ -4,17 +4,18 @@ import $ from 'jquery';
 import { CONTENT_TYPES } from '~/src/state/viewer/viewer-constants';
 import { APP_CONSTANTS } from '~/src/utils/app-constants';
 import { buildSearchPayload } from '~/src/api/search-api';
+import { store } from '~/src/index';
 
 export function fetchItems(pageNumber) {
     const searchGroups = store.getState().search.searchGroups;
-    if (searchGroups.length == 0) {
+    if (searchGroups.length === 0) {
         return ajax('GET', `documents?page=${pageNumber}`);
-    } else {
-        const payload = {
-            search: buildSearchPayload(searchGroups),
-        }
-        return ajax('POST', `documents/search?page=${pageNumber}`, payload);
     }
+
+    const payload = {
+        search: buildSearchPayload(searchGroups),
+    };
+    return ajax('POST', `documents/search?page=${pageNumber}`, payload);
 }
 
 export function fetchItem(itemId) {

--- a/src/api/search-api.js
+++ b/src/api/search-api.js
@@ -3,7 +3,14 @@ import { ajax } from '~/src/utils/utils';
 import { SEARCH_CONSTANTS } from '~/src/state/search/search-constants';
 
 export function search(searchGroups) {
-    const searchPayload = Object.keys(searchGroups).map((index) => {
+    const payload = {
+        search: buildSearchPayload(searchGroups),
+    };
+    return ajax('POST', 'documents/search', payload);
+}
+
+export function buildSearchPayload(searchGroups) {
+    return Object.keys(searchGroups).map((index) => {
         const searchGroup = searchGroups[index];
         switch (searchGroup.groupType) {
             case (SEARCH_CONSTANTS.ITEM_TYPE): {
@@ -51,8 +58,4 @@ export function search(searchGroups) {
         }
         return null;
     });
-    const payload = {
-        search: searchPayload,
-    };
-    return ajax('POST', 'documents/search', payload);
 }

--- a/src/api/search-api.js
+++ b/src/api/search-api.js
@@ -2,13 +2,6 @@ import config from '~/config';
 import { ajax } from '~/src/utils/utils';
 import { SEARCH_CONSTANTS } from '~/src/state/search/search-constants';
 
-export function search(searchGroups) {
-    const payload = {
-        search: buildSearchPayload(searchGroups),
-    };
-    return ajax('POST', 'documents/search', payload);
-}
-
 export function buildSearchPayload(searchGroups) {
     return Object.keys(searchGroups).map((index) => {
         const searchGroup = searchGroups[index];
@@ -58,4 +51,11 @@ export function buildSearchPayload(searchGroups) {
         }
         return null;
     });
+}
+
+export function search(searchGroups) {
+    const payload = {
+        search: buildSearchPayload(searchGroups),
+    };
+    return ajax('POST', 'documents/search', payload);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,7 @@ import { App, Auth, Home, Login, Upload, Settings, Viewer } from './views';
 import './assets/style/style.scss';
 
 
-const store = configureStore();
-window.store = store;
+export const store = configureStore();
 
 const history = syncHistoryWithStore(browserHistory, store);
 

--- a/src/state/search/search-reducers.js
+++ b/src/state/search/search-reducers.js
@@ -245,6 +245,12 @@ export default function (state = initialState, action) {
                 searchGroups: updateGroupValue(searchGroups, groupIndex, 'terms', terms),
             };
         }
+
+        case searchActionTypes.SEARCH_RESET: {
+            return {
+                ...initialState,
+            };
+        }
     }
     return state;
 }


### PR DESCRIPTION
I’m tempted to consolidate the search and non-search endpoints together since they seem redundant.