### PR TITLE
ARC-175+205: Clarify tagging + indicate what date added field really is

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -3,22 +3,34 @@ import './tooltip.scss';
 
 export default class Tooltip extends Component {
 
+    static DIRECTION = {
+        top: 'top',
+        bottom: 'bottom',
+        left: 'left',
+        right: 'right',
+    };
+
     static MESSAGES = {
         tagEntry: 'Press the enter key to submit the tag.',
         dateAdded: 'Date Added',
     };
 
     static propTypes = {
+        direction: PropTypes.string,
         message: PropTypes.string,
     };
 
+    static defaultProps = {
+        direction: 'top',
+    };
+
     render() {
-        const { message } = this.props;
+        const { message, direction } = this.props;
 
         return (
             <div className='tooltip2'>
                 <div className='questionmark'>?</div>
-                <span className='tooltiptext'>{message}</span>
+                <span className={`tooltiptext ${direction}`}>{message}</span>
             </div>
         );
     }

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -1,0 +1,24 @@
+import React, { PropTypes, Component } from 'react';
+import './tooltip.scss';
+
+export default class Tooltip extends Component {
+
+    static MESSAGES = {
+        tagEntry: 'Press the enter key to submit the tag.',
+    };
+
+    static propTypes = {
+        message: PropTypes.string,
+    };
+
+    render() {
+        const { message } = this.props;
+
+        return (
+            <div className='tooltip2'>
+                <div className='questionmark'>?</div>
+                <span className='tooltiptext'>{message}</span>
+            </div>
+        );
+    }
+}

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -5,6 +5,7 @@ export default class Tooltip extends Component {
 
     static MESSAGES = {
         tagEntry: 'Press the enter key to submit the tag.',
+        dateAdded: 'Date Added',
     };
 
     static propTypes = {

--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -1,0 +1,43 @@
+@import '../../defaults';
+
+.tooltip2 {
+    margin-left: 7px;
+    position: relative;
+    display: inline-block;
+
+    .questionmark {
+      color: #0000ff;
+      border-top: 0px;
+      border-left: 0px;
+      border-right: 0px;
+      border-bottom: 2px;
+      border-style: dotted;
+      border-color: #0000ff;
+    }
+
+    .tooltiptext {
+        visibility: hidden;
+        width: 120px;
+        background-color: #555;
+        color: #fff;
+        text-align: center;
+        padding: 5px 0;
+        border-radius: 6px;
+
+        /* Position the tooltip text */
+        position: absolute;
+        z-index: 1;
+        bottom: 125%;
+        left: 50%;
+        margin-left: -60px;
+
+        /* Fade in tooltip */
+        opacity: 0;
+        transition: opacity 1s;
+    }
+
+    &:hover .tooltiptext {
+        visibility: visible;
+        opacity: 1;
+    }
+}

--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -16,7 +16,6 @@
     }
 
     .tooltiptext {
-        visibility: hidden;
         width: 120px;
         background-color: #555;
         color: #fff;
@@ -37,7 +36,6 @@
     }
 
     &:hover .tooltiptext {
-        visibility: visible;
         opacity: 1;
     }
 }

--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -26,13 +26,33 @@
         /* Position the tooltip text */
         position: absolute;
         z-index: 1;
-        bottom: 125%;
-        left: 50%;
-        margin-left: -60px;
 
         /* Fade in tooltip */
         opacity: 0;
         transition: opacity 1s;
+
+        &.top {
+            bottom: 125%;
+            left: 50%;
+            margin-left: -60px;
+        }
+
+        &.bottom {
+            top: 135%;
+            left: 50%;
+            margin-left: -60px;
+        }
+
+        &.left {
+            top: -5px;
+            bottom: auto;
+            right: 150%;
+        }
+
+        &.right {
+            top: -5px;
+            left: 150%;
+        }
     }
 
     &:hover .tooltiptext {

--- a/src/views/sidebar/components/summary-tab/summary-tab.js
+++ b/src/views/sidebar/components/summary-tab/summary-tab.js
@@ -98,7 +98,7 @@ export default class SummaryTab extends Component {
                 </section>
                 <section className='summary-tab-tags'>
                     <span className='summary-tab-category'>Tags</span>
-                    <Tooltip message={Tooltip.MESSAGES.tagEntry} />
+                    <Tooltip message={Tooltip.MESSAGES.tagEntry} direction={Tooltip.DIRECTION.right} />
                     <TagsInput
                         value={activeItem.tags || []}
                         onChange={this.handleTagsUpdated}

--- a/src/views/sidebar/components/summary-tab/summary-tab.js
+++ b/src/views/sidebar/components/summary-tab/summary-tab.js
@@ -1,5 +1,6 @@
 import React, { PropTypes, Component } from 'react';
 import TagsInput from 'react-tagsinput';
+import Tooltip from '~/src/components/tooltip/tooltip';
 import DescriptionBox from '~/src/components/description-box/description-box';
 import { formatDate } from '~/src/utils/utils';
 import { canEditMetadata } from '~/src/state/user/privileges';
@@ -97,6 +98,7 @@ export default class SummaryTab extends Component {
                 </section>
                 <section className='summary-tab-tags'>
                     <span className='summary-tab-category'>Tags</span>
+                    <Tooltip message={Tooltip.MESSAGES.tagEntry} />
                     <TagsInput
                         value={activeItem.tags || []}
                         onChange={this.handleTagsUpdated}

--- a/src/views/upload/components/upload.js
+++ b/src/views/upload/components/upload.js
@@ -1,4 +1,5 @@
 import React, { PropTypes, Component } from 'react';
+import Tooltip from '~/src/components/tooltip/tooltip'
 import TagsInput from 'react-tagsinput';
 import moment from 'moment';
 import './upload.scss';
@@ -233,9 +234,8 @@ export default class Upload extends Component {
                         <label htmlFor='file-5'>
                             <figure>
                                 <svg xmlns='http://www.w3.org/2000/svg' width='20' height='17' viewBox='0 0 20 17'>
-                                    <path
-                                        d='M10 0l-5.2 4.9h3.3v5.1h3.8v-5.1h3.3l-5.2-4.9zm9.3 11.5l-3.2-2.1h-2l3.4 2.6h-3.5c-.1 0-.2.1-.2.1l-.8 2.3h-6l-.8-2.2c-.1-.1-.1-.2-.2-.2h-3.6l3.4-2.6h-2l-3.2 2.1c-.4.3-.7 1-.6 1.5l.6 3.1c.1.5.7.9 1.2.9h16.3c.6 0 1.1-.4 1.3-.9l.6-3.1c.1-.5-.2-1.2-.7-1.5z'
-                                    />
+                                  <path d='M9,89a81,81 0 1,1 0,2zm51-14c0-13 1-19 8-26c7-9 18-10 28-8c10,2 22,12 22,26c0,14-11,19-15,22c-3,3-5,6-5,9v22m0,12v16'>
+                                  </path>
                                 </svg>
                             </figure>
                             <span>{fileName}</span></label>
@@ -263,6 +263,7 @@ export default class Upload extends Component {
                             </div>
                         )}
                         <p className='upload-label'>Tags</p>
+                        <Tooltip message={Tooltip.MESSAGES.tagEntry} />
                         <TagsInput value={tags} onChange={this.handleTagChange} />
                         <div>
                             <p className='upload-label'>Description</p>

--- a/src/views/upload/components/upload.js
+++ b/src/views/upload/components/upload.js
@@ -1,5 +1,5 @@
 import React, { PropTypes, Component } from 'react';
-import Tooltip from '~/src/components/tooltip/tooltip'
+import Tooltip from '~/src/components/tooltip/tooltip';
 import TagsInput from 'react-tagsinput';
 import moment from 'moment';
 import './upload.scss';

--- a/src/views/upload/components/upload.js
+++ b/src/views/upload/components/upload.js
@@ -191,24 +191,24 @@ export default class Upload extends Component {
         setDescription(value);
     }
 
-    renderMetadataRows = (object) => {
+    renderMetadataRows = (group) => {
         const { allItemID } = this.props;
-        const idKey = allItemID.indexOf(object.id);
+        const idKey = allItemID.indexOf(group.id);
         if (idKey < 0) { return; }
 
         return (
             <div key={idKey}>
-                {object.fields.map((obj, fieldKey) =>
-                    <div className='metadata-fields' htmlFor={object.id} key={fieldKey}>
-                        {obj.name === 'Date Added' ?
+                {group.fields.map((field, fieldKey) =>
+                    <div className='metadata-fields' htmlFor={group.id} key={fieldKey}>
+                        {field.name === 'Date Added' ?
                             <input
                                 className='input-text' type='text' value={moment().format('MM/DD/YYYY')}
                                 disabled
                             /> :
                             <input
-                                className='input-text' name={obj.name} id={object.id} data-type={obj.type}
+                                className='input-text' name={field.name} id={group.id} data-type={field.type}
                                 onBlur={this.handleMetaDataTextChange} type='text'
-                                placeholder={obj.name}
+                                placeholder={field.name}
                             />
                         }
                     </div>

--- a/src/views/upload/components/upload.js
+++ b/src/views/upload/components/upload.js
@@ -191,6 +191,32 @@ export default class Upload extends Component {
         setDescription(value);
     }
 
+    renderMetadataRows = (object) => {
+        const { allItemID } = this.props;
+        const idKey = allItemID.indexOf(object.id);
+        if (idKey < 0) { return; }
+
+        return (
+            <div key={idKey}>
+                {object.fields.map((obj, fieldKey) =>
+                    <div className='metadata-fields' htmlFor={object.id} key={fieldKey}>
+                        {obj.name === 'Date Added' ?
+                            <input
+                                className='input-text' type='text' value={moment().format('MM/DD/YYYY')}
+                                disabled
+                            /> :
+                            <input
+                                className='input-text' name={obj.name} id={object.id} data-type={obj.type}
+                                onBlur={this.handleMetaDataTextChange} type='text'
+                                placeholder={obj.name}
+                            />
+                        }
+                    </div>
+                )}
+            </div>
+        );
+    }
+
     render() {
         const { groups, tags, allItemID, fileName, description } = this.props;
         return (
@@ -219,46 +245,22 @@ export default class Upload extends Component {
                 <div className='right-half'>
                     <h4>Information about the file can be entered below:</h4>
                     <div className='container'>
-                        <p className='upload-label'>Categories:</p>
-                        <input id='generic' type='checkbox' value='generic' disabled checked='true' />
-                        <label htmlFor='generic'>Generic *</label>
                         {groups.map((object, key) =>
-                            <div className='upload-category'>
-                                {object.name !== 'Generic' ?
-                                    <div key={key}>
+                            <div>
+                                <div>
+                                    {object.name !== 'Generic' ?
                                         <input
+                                            className='metadata-group-select'
                                             type='checkbox'
                                             checked={object.checkbox}
                                             id={object.id}
                                             onChange={this.handleOnItemSelect}
                                         />
-                                        <label htmlFor={object.id}>{object.name}</label>
-                                    </div>
                                     : null}
-                            </div>,
-                        )}
-                        <br />
-                        <p className='upload-label'>Meta Data:</p>
-                        {allItemID.map((ID, idKey) =>
-                            <div key={idKey}>
-                                <p className='metadata-group'>{groups.filter(x => x.id === ID)[0].name}</p>
-                                {groups.filter(x => x.id === ID)[0].fields.map((obj, fieldKey) =>
-                                    <div className='metadata-fields' htmlFor={ID} key={fieldKey}>
-                                        {obj.name === 'Date Added' ?
-                                            <input
-                                                className='input-text' type='text' value={moment().format('MM/DD/YYYY')}
-                                                disabled
-                                            /> :
-                                            <input
-                                                className='input-text' name={obj.name} id={ID} data-type={obj.type}
-                                                onBlur={this.handleMetaDataTextChange} type='text'
-                                                placeholder={obj.name}
-                                            />
-                                        }
-                                    </div>,
-                                )
-                                }
-                            </div>,
+                                    <p className='upload-label'>{object.name}</p>
+                                </div>
+                                {this.renderMetadataRows(object)}
+                            </div>
                         )}
                         <p className='upload-label'>Description:</p>
                         <textarea

--- a/src/views/upload/components/upload.js
+++ b/src/views/upload/components/upload.js
@@ -202,10 +202,10 @@ export default class Upload extends Component {
                 {group.fields.map((field, fieldKey) =>
                     <div className='metadata-fields' htmlFor={group.id} key={fieldKey}>
                         {field.name === 'Date Added' ?
-                            <input
-                                className='input-text' type='text' value={moment().format('MM/DD/YYYY')}
-                                disabled
-                            /> :
+                            <div>
+                                <input className='input-text' type='text' value={moment().format('MM/DD/YYYY')} disabled />
+                                <Tooltip message={Tooltip.MESSAGES.dateAdded} />
+                            </div> :
                             <input
                                 className='input-text' name={field.name} id={group.id} data-type={field.type}
                                 onBlur={this.handleMetaDataTextChange} type='text'

--- a/src/views/upload/components/upload.js
+++ b/src/views/upload/components/upload.js
@@ -262,10 +262,10 @@ export default class Upload extends Component {
                                 {this.renderMetadataRows(object)}
                             </div>
                         )}
-                        <p className='upload-label'>Tags:</p>
+                        <p className='upload-label'>Tags</p>
                         <TagsInput value={tags} onChange={this.handleTagChange} />
                         <div>
-                            <p className='upload-label'>Description:</p>
+                            <p className='upload-label'>Description</p>
                             <textarea
                                 value={description} type='text' placeholder='Add a description'
                                 onChange={this.handleDescriptionChange}

--- a/src/views/upload/components/upload.js
+++ b/src/views/upload/components/upload.js
@@ -262,13 +262,15 @@ export default class Upload extends Component {
                                 {this.renderMetadataRows(object)}
                             </div>
                         )}
-                        <p className='upload-label'>Description:</p>
-                        <textarea
-                            value={description} type='text' placeholder='Add a description'
-                            onChange={this.handleDescriptionChange}
-                        />
                         <p className='upload-label'>Tags:</p>
                         <TagsInput value={tags} onChange={this.handleTagChange} />
+                        <div>
+                            <p className='upload-label'>Description:</p>
+                            <textarea
+                                value={description} type='text' placeholder='Add a description'
+                                onChange={this.handleDescriptionChange}
+                                />
+                        </div>
                         <br />
                     </div>
                     <div className='upload-submit'>

--- a/src/views/upload/components/upload.js
+++ b/src/views/upload/components/upload.js
@@ -234,8 +234,7 @@ export default class Upload extends Component {
                         <label htmlFor='file-5'>
                             <figure>
                                 <svg xmlns='http://www.w3.org/2000/svg' width='20' height='17' viewBox='0 0 20 17'>
-                                  <path d='M9,89a81,81 0 1,1 0,2zm51-14c0-13 1-19 8-26c7-9 18-10 28-8c10,2 22,12 22,26c0,14-11,19-15,22c-3,3-5,6-5,9v22m0,12v16'>
-                                  </path>
+                                    <path d='M10 0l-5.2 4.9h3.3v5.1h3.8v-5.1h3.3l-5.2-4.9zm9.3 11.5l-3.2-2.1h-2l3.4 2.6h-3.5c-.1 0-.2.1-.2.1l-.8 2.3h-6l-.8-2.2c-.1-.1-.1-.2-.2-.2h-3.6l3.4-2.6h-2l-3.2 2.1c-.4.3-.7 1-.6 1.5l.6 3.1c.1.5.7.9 1.2.9h16.3c.6 0 1.1-.4 1.3-.9l.6-3.1c.1-.5-.2-1.2-.7-1.5z' />
                                 </svg>
                             </figure>
                             <span>{fileName}</span></label>

--- a/src/views/upload/components/upload.scss
+++ b/src/views/upload/components/upload.scss
@@ -151,6 +151,14 @@
     text-align: center;
     padding-top: 10%;
   }
+
+  .upload-label {
+    display: inline-block;
+  }
+
+  .metadata-group-select {
+    margin-right: 7px;
+  }
   //--------------------end of upload icon and labels--------------
 
   //--------------text boxes------------------

--- a/src/views/upload/components/upload.scss
+++ b/src/views/upload/components/upload.scss
@@ -168,7 +168,7 @@
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     outline: none;
-    display: block;
+    display: inline-block;
     width: 50%;
     padding: 7px;
     border: none;


### PR DESCRIPTION
**IMPORTANT:** A bunch of the changes in this PR currently are from https://github.com/ArchivistProject/archivist-web/pull/37 -- once that gets merged in we'll be able to see the changes for this pr alone more clearly.

<img width="349" alt="screen shot 2017-05-08 at 1 11 14 pm" src="https://cloud.githubusercontent.com/assets/5169821/25816041/cb631158-33f0-11e7-9bf7-4210fcc8076e.png">
<img width="363" alt="screen shot 2017-05-08 at 1 11 21 pm" src="https://cloud.githubusercontent.com/assets/5169821/25816049/ce04cc1c-33f0-11e7-9edb-14814e1bbdec.png">
<img width="558" alt="screen shot 2017-05-08 at 1 11 32 pm" src="https://cloud.githubusercontent.com/assets/5169821/25816057/d12b05be-33f0-11e7-96af-f65d3581a481.png">
