### PR TITLE
ARC-223: Change color of sidebar tabs

### DIFF
--- a/src/views/action-bar/components/action-bar.scss
+++ b/src/views/action-bar/components/action-bar.scss
@@ -8,6 +8,7 @@
     height: $action-bar-height;
     min-width: $app-min-width;
     line-height: $action-bar-height;
+    border-bottom: 2px solid $darker-primary-color;
 
     &-left {
         margin: 0 $gutter;

--- a/src/views/sidebar/components/sidebar.scss
+++ b/src/views/sidebar/components/sidebar.scss
@@ -16,15 +16,14 @@
     &-tabs {
         display: flex;
         height: 25px;
-        border-color: $darker-secondary-color;
-        border-style: solid;
-        border-width: 0 0 1px;
+        border-bottom: 1px solid $darker-primary-color;
         width: 100%;
 
         &-item { //the tabs
             flex-grow: 1;
             outline: none;
             border: none;
+            color: $primary-color;
             background-color: $bg-primary-color;
             
             font-family: $default-family;
@@ -32,12 +31,13 @@
 
             &:disabled {
                 cursor: default;
-                background-color: $secondary-color;
-                color: $primary-color;
+                background-color: $primary-color;
+                color: $bg-primary-color;
             }
 
             &:enabled:hover {
                 color: $primary-color;
+                background-color: $light-primary-color;
             }
         }
     }


### PR DESCRIPTION
This also adds a 2px border below the action bar (I think it looks a little better)

Summary selected:
<img width="335" alt="screen shot 2017-05-16 at 6 39 50 pm" src="https://cloud.githubusercontent.com/assets/6114497/26131306/2e6b2764-3a67-11e7-8c2c-76c09ee85d81.png">

Summary selected and search hovered:
<img width="321" alt="screen shot 2017-05-16 at 6 39 53 pm" src="https://cloud.githubusercontent.com/assets/6114497/26131305/2e6406b4-3a67-11e7-972c-e1178b503d9e.png">