### PR TITLE
ARC-233: Remove empty search terms from simple search

### DIFF
--- a/src/state/search/search-reducers.js
+++ b/src/state/search/search-reducers.js
@@ -284,7 +284,7 @@ export default function (state = initialState, action) {
 
         case searchActionTypes.SETUP_SIMPLE_SEARCH: {
             const { terms } = action.data;
-            const termArray = terms.split(' ');
+            const termArray = terms.split(' ').filter(t => t.length !== 0);
             return {
                 ...state,
                 hasFullText: true,
@@ -303,13 +303,13 @@ export default function (state = initialState, action) {
                         andOr: SEARCH_CONSTANTS.AND,
                         not: false,
                         groupType: SEARCH_CONSTANTS.DESCRIPTION,
-                        description: terms,
+                        description: termArray.join(' '),
                     },
                     {
                         andOr: SEARCH_CONSTANTS.AND,
                         not: false,
                         groupType: SEARCH_CONSTANTS.FULLTEXT,
-                        terms,
+                        terms: termArray.join(' '),
                     },
                 ],
             };


### PR DESCRIPTION
If the user hits space multiple times in a row it’ll now filter that out.