### PR TITLE
ARC-196+239: Fix the column width for the main file list

### DIFF
--- a/src/components/grid/grid.js
+++ b/src/components/grid/grid.js
@@ -42,7 +42,7 @@ export default class Grid extends Component {
         const { headers, sortBy, sortOrder } = this.props;
         return headers.map((header, key) =>
             (
-                <th className='grid-header-item' key={key} onClick={() => this.handleHeaderClick(header)}>
+                <th className={`grid-header-item ${header.toLowerCase().replace(/ /i, '_')}`} key={key} onClick={() => this.handleHeaderClick(header)}>
                     {header}
                     {sortBy === header ?
                         <span className={sortOrder === 'ascending' ? 'glyphicon glyphicon-arrow-up' : 'glyphicon glyphicon-arrow-down'} />

--- a/src/components/grid/grid.scss
+++ b/src/components/grid/grid.scss
@@ -15,6 +15,16 @@
         font-family: $default-family;
         font-size: $default-size;
         cursor: pointer;
+
+        &.title {
+            width: 55%;
+        }
+        &.author {
+            width: 25%;
+        }
+        &.date_added {
+            width: 20%;
+        }
     }
 
     &-header-item {


### PR DESCRIPTION
<img width="808" alt="screen shot 2017-05-21 at 3 21 13 pm" src="https://cloud.githubusercontent.com/assets/5169821/26286703/beeacdaa-3e39-11e7-8067-c799a513e413.png">

Now they won't change when you change pages or change the sort order.